### PR TITLE
add styles for fix header link to be color of white - [DR]

### DIFF
--- a/cccm-frontend/src/assets/css/overrides.css
+++ b/cccm-frontend/src/assets/css/overrides.css
@@ -14,6 +14,18 @@
     width:100%!important;
     max-width:100%!important;
 }
+
+
+/* HEADER SECTION todo: put in own file */
+
+.headerText a {
+    color:#fff!important;
+}
+.headerText a:visited {
+    color:#fff!important;
+}
+
+
 /* CLIENT SEARCH todo: put in own file */
 
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Office link in header now matches rest of design color

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Visually localhost

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
