### PR TITLE
fixes issue where v-window class obstructs position sticky - [DR]

### DIFF
--- a/cccm-frontend/src/assets/css/overrides.css
+++ b/cccm-frontend/src/assets/css/overrides.css
@@ -1,3 +1,6 @@
+.v-window {
+    overflow: unset!important;
+}
 .v-btn {
     text-transform: unset !important;
 }
@@ -128,7 +131,6 @@ label.col-form-label {
 .tippy-content {
     background-color: #38598A;
 }
-
 
 /*FORM IO CUSTOM CSS CLASSES - TODO: Put in different file*/
 .formio-location-input-container{


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

fixes the issue where the menu on crna-cmp and sara-cmp were not sticky due to a parent class having overflow property. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Visually on localhost

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
