### PR TITLE
Updated the datatable key to make it unique

### DIFF
--- a/cccm-frontend/src/components/common/FormioClientSearch.vue
+++ b/cccm-frontend/src/components/common/FormioClientSearch.vue
@@ -241,12 +241,11 @@ export default {
     },
     private_getLimitedToCurrentActiveLocation() {
       let limitedToCurrentActiveLocation = false;
-      let checkbox = document.getElementsByName("data[limitedToCurrentActiveLocation]");
-      //console.log("checkbox: ", checkbox, checkbox[0], checkbox[0].checked);
-      if (checkbox != null &&  checkbox[0] != null) {
-        limitedToCurrentActiveLocation = checkbox[0].checked;
-      }
-      //console.log("limitedToCurrentActiveLocation: ", limitedToCurrentActiveLocation);
+      // Commented out on Jan 27, 2023. Will enable it once this option is back.
+      // let checkbox = document.getElementsByName("data[limitedToCurrentActiveLocation]");
+      // if (checkbox != null &&  checkbox[0] != null) {
+      //   limitedToCurrentActiveLocation = checkbox[0].checked;
+      // }
       return limitedToCurrentActiveLocation;
     },
     private_processSearchResults(error, response) {

--- a/cccm-frontend/src/components/common/FormioClientSearch.vue
+++ b/cccm-frontend/src/components/common/FormioClientSearch.vue
@@ -39,7 +39,7 @@
         :single-expand="singleExpand"
         :expanded.sync="expanded"
         @item-expanded="expandRow"
-        item-key="clientNum"
+        item-key="index"
         no-results-text="No clients found"
         :search="search"
         show-expand
@@ -262,7 +262,9 @@ export default {
         this.clients = response;
 
         // populate primary address info 
+        let index = 0;
         this.clients = this.clients.filter(el => {
+          el.index = index++;
           // Map primary address and primary addressType
           if (el.address != null && el.address.length == 1) {
             el.fullAddress = el.address[0].fullAddress;

--- a/cccm-frontend/src/components/common/templateClientSearch.json
+++ b/cccm-frontend/src/components/common/templateClientSearch.json
@@ -100,14 +100,6 @@
                     "tableView": false
                 },
                 {
-                    "label": "Limit search to current active location",
-                    "tableView": false,
-                    "key": "limitedToCurrentActiveLocation",
-                    "type": "checkbox",
-                    "input": true,
-                    "defaultValue": false
-                },
-                {
                     "label": "Tabs",
                     "components": [
                         {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- CBCCCM-678: Fix the key used by client search result datatable
- Removed 'Limit search to current active location' checkbox

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
Manually tested.

Please describe the tests that you ran to verify your changes.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
