### PR TITLE
Added the styling to readonly fields

### DIFF
--- a/cccm-frontend/src/assets/css/overrides.css
+++ b/cccm-frontend/src/assets/css/overrides.css
@@ -623,3 +623,15 @@ legend[ref="header"]{
     color: red;
     font-weight: bold;
 }
+
+/* READONLY fields style*/
+.readonly-field-title {
+    font-size: 1rem; 
+    font-weight: 700; 
+    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,"Apple Color Emoji","Segoe UI Emoji",Segoe UI Symbol,"Noto Color Emoji"
+}
+
+.readonly-field-text {
+    font-size: 1rem; 
+    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,"Apple Color Emoji","Segoe UI Emoji",Segoe UI Symbol,"Noto Color Emoji"
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- CBCCCM-814: Supervision Rating displaying unicode text

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
