### PR TITLE
Added logic to skip autoCalc for saveFormAnswers triggered by form clone

### DIFF
--- a/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/form/FormsApiImpl.java
+++ b/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/form/FormsApiImpl.java
@@ -78,7 +78,7 @@ public class FormsApiImpl implements FormsApi {
             loadLatestValues = Boolean.FALSE;
         }
 
-        return clientDataService.saveClientFormAnswers(clientNumber, clientFormId, answerPayload, loadLatestValues, xLocationId);
+        return clientDataService.saveClientFormAnswers(clientNumber, clientFormId, answerPayload, false, loadLatestValues, xLocationId);
     }
 
     @Override

--- a/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientDataService.java
+++ b/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientDataService.java
@@ -26,11 +26,12 @@ public interface ClientDataService {
      * @param clientNumber
      * @param clientFormId the form Id
      * @param payload the JSON representation of the form data
+	 * @param skipAutoCalc set true to bypass the autoCalc logic while saving the form answers, e.g., set it to true while cloning form.
      * @param loadLatestAnswers set true to return latest answers - has performance overhead so only use if saving the whole form, not a single question
      *
      * @return {@link String} JSON value of answers if loadLatest is requested
      */
-    String saveClientFormAnswers(String clientNumber, BigDecimal clientFormId, String payload, boolean loadLatestAnswers, String location);
+    String saveClientFormAnswers(String clientNumber, BigDecimal clientFormId, String payload, boolean skipAutoCalc, boolean loadLatestAnswers, String location);
 
 
     /**

--- a/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientDataServiceImpl.java
+++ b/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientDataServiceImpl.java
@@ -278,9 +278,9 @@ public class ClientDataServiceImpl implements ClientDataService {
     }
 
     @Override
-    public String saveClientFormAnswers(String clientNumber,BigDecimal clientFormId, String payload, boolean loadLatestValues, String location) {
+    public String saveClientFormAnswers(String clientNumber,BigDecimal clientFormId, String payload, boolean skipAutoCalc, boolean loadLatestValues, String location) {
         logger.debug("Saving client form answers {}", clientFormId);
-        return obridgeClientService.saveClientFormAnswers(clientNumber,clientFormId, payload, loadLatestValues, new BigDecimal(location));
+        return obridgeClientService.saveClientFormAnswers(clientNumber,clientFormId, payload, skipAutoCalc, loadLatestValues, new BigDecimal(location));
 
     }
 

--- a/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientFormSaveServiceImpl.java
+++ b/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientFormSaveServiceImpl.java
@@ -355,7 +355,7 @@ public class ClientFormSaveServiceImpl implements ClientFormSaveService {
         String answers = obridgeClientService.getClientFormAnswers(cloneFormRequest.getClientNumber(), clientFormSummary.getId(), new BigDecimal(location));
         //Insert Answers Use Clone Config for ignore
         String strippedAnswers = stripAnswers(answers, cloneConfig.getForms().stream().filter(cloneForm -> cloneForm.getFormType().equalsIgnoreCase(clientFormSummary.getModule())).findFirst().get());
-        obridgeClientService.saveClientFormAnswers(cloneFormRequest.getClientNumber(), clientFormId, strippedAnswers, false, new BigDecimal(location));
+        obridgeClientService.saveClientFormAnswers(cloneFormRequest.getClientNumber(), clientFormId, strippedAnswers, true, false, new BigDecimal(location));
 
         return clientFormId;
 

--- a/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ObridgeClientService.java
+++ b/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ObridgeClientService.java
@@ -166,6 +166,7 @@ public interface ObridgeClientService {
     String saveClientFormAnswers(@PathParam("clientNumber") String clientNumber,
             @PathParam("clientFormId") BigDecimal clientFormId,
             @RequestBody String payload,
+			@QueryParam("skipAutoCalc") boolean skipAutoCalc,
             @QueryParam("loadLatestValues") boolean loadLatestValues,
             @QueryParam("location") BigDecimal location);
 

--- a/cccm-backend/cccm-api/src/test/java/ca/bc/gov/open/jag/api/form/SaveClientFormAnswersUsingPUTTest.java
+++ b/cccm-backend/cccm-api/src/test/java/ca/bc/gov/open/jag/api/form/SaveClientFormAnswersUsingPUTTest.java
@@ -47,7 +47,7 @@ public class SaveClientFormAnswersUsingPUTTest {
     @DisplayName("201: should link form")
     public void testGetSuccess() {
 
-        Mockito.when(clientDataService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString())).thenReturn(TEST);
+        Mockito.when(clientDataService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyString())).thenReturn(TEST);
 
         LinkFormInput linkFormInput = new LinkFormInput();
         linkFormInput.setClientFormId(BigDecimal.ONE);

--- a/cccm-backend/cccm-api/src/test/java/ca/bc/gov/open/jag/api/service/dataservice/clientForm/CloneFormTest.java
+++ b/cccm-backend/cccm-api/src/test/java/ca/bc/gov/open/jag/api/service/dataservice/clientForm/CloneFormTest.java
@@ -128,7 +128,7 @@ public class CloneFormTest {
         Mockito.when(obridgeClientService.createForm(Mockito.any())).thenReturn(BigDecimal.ONE);
         Mockito.when(obridgeClientService.getFormTypes(Mockito.any())).thenReturn(Collections.singletonList(createCodeTable(CRNA_FORM_TYPE, BigDecimal.ONE.toPlainString())));
         Mockito.when(obridgeClientService.getClientFormAnswers(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DATA_ONE);
-        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
+        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
 
         BigDecimal result = sut.cloneClientForm(new CloneFormRequest("TEST", BigDecimal.ONE, BigDecimal.ONE, true), "TEST@idir", "1");
 
@@ -144,7 +144,7 @@ public class CloneFormTest {
         Mockito.when(obridgeClientService.createForm(Mockito.any())).thenReturn(BigDecimal.ONE);
         Mockito.when(obridgeClientService.getFormTypes(Mockito.any())).thenReturn(Collections.singletonList(createCodeTable(SARA_FORM_TYPE, BigDecimal.ONE.toPlainString())));
         Mockito.when(obridgeClientService.getClientFormAnswers(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DATA_ONE);
-        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
+        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
 
         BigDecimal result = sut.cloneClientForm(new CloneFormRequest("TEST", BigDecimal.ONE, BigDecimal.ONE, true), "TEST@idir", "1");
 
@@ -160,7 +160,7 @@ public class CloneFormTest {
         Mockito.when(obridgeClientService.createForm(Mockito.any())).thenReturn(BigDecimal.ONE);
         Mockito.when(obridgeClientService.getFormTypes(Mockito.any())).thenReturn(Collections.singletonList(createCodeTable(SARA_FORM_TYPE, BigDecimal.ONE.toPlainString())));
         Mockito.when(obridgeClientService.getClientFormAnswers(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DATA_ONE);
-        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
+        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
 
         BigDecimal result = sut.cloneClientForm(new CloneFormRequest("TEST", BigDecimal.ONE, BigDecimal.ONE, true), "TEST@idir", "1");
 
@@ -176,7 +176,7 @@ public class CloneFormTest {
         Mockito.when(obridgeClientService.createForm(Mockito.any())).thenReturn(BigDecimal.ONE);
         Mockito.when(obridgeClientService.getFormTypes(Mockito.any())).thenReturn(Collections.singletonList(createCodeTable(ACUTE_FORM_TYPE, BigDecimal.ONE.toPlainString())));
         Mockito.when(obridgeClientService.getClientFormAnswers(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DATA_ONE);
-        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
+        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
 
         BigDecimal result = sut.cloneClientForm(new CloneFormRequest("TEST", BigDecimal.ONE, BigDecimal.ONE, true), "TEST@idir", "1");
 
@@ -193,7 +193,7 @@ public class CloneFormTest {
         Mockito.when(obridgeClientService.createForm(Mockito.any())).thenReturn(BigDecimal.ONE);
         Mockito.when(obridgeClientService.getFormTypes(Mockito.any())).thenReturn(Collections.singletonList(createCodeTable(STATIC99R_FORM_TYPE, BigDecimal.ONE.toPlainString())));
         Mockito.when(obridgeClientService.getClientFormAnswers(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DATA_ONE);
-        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
+        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
 
         BigDecimal result = sut.cloneClientForm(new CloneFormRequest("TEST", BigDecimal.ONE, BigDecimal.ONE, true), "TEST@idir", "1");
 
@@ -209,7 +209,7 @@ public class CloneFormTest {
         Mockito.when(obridgeClientService.createForm(Mockito.any())).thenReturn(BigDecimal.ONE);
         Mockito.when(obridgeClientService.getFormTypes(Mockito.any())).thenReturn(Collections.singletonList(createCodeTable(SARA_FORM_TYPE, BigDecimal.TEN.toPlainString())));
         Mockito.when(obridgeClientService.getClientFormAnswers(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DATA_ONE);
-        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
+        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
 
         Assertions.assertThrows(CCCMException.class, () -> sut.cloneClientForm(new CloneFormRequest("TEST", BigDecimal.ONE, BigDecimal.ONE, false), "NOTTEST@idir", "1"));
 
@@ -224,7 +224,7 @@ public class CloneFormTest {
         Mockito.when(obridgeClientService.createForm(Mockito.any())).thenReturn(BigDecimal.ONE);
         Mockito.when(obridgeClientService.getFormTypes(Mockito.any())).thenReturn(Collections.singletonList(createCodeTable(SARA_FORM_TYPE, BigDecimal.TEN.toPlainString())));
         Mockito.when(obridgeClientService.getClientFormAnswers(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DATA_ONE);
-        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
+        Mockito.when(obridgeClientService.saveClientFormAnswers(Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any())).thenReturn("");
 
         Assertions.assertThrows(CCCMException.class, () -> sut.cloneClientForm(new CloneFormRequest("TEST", BigDecimal.ONE, BigDecimal.ONE, true), "TEST@idir", "1"));
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- CBCCCM-953: Acute Total Score - Three Answers

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
