### PR TITLE
Fixed the intervention comments display issue in case plan section

### DIFF
--- a/cccm-frontend/src/components/form/formSections/FormCasePlan.vue
+++ b/cccm-frontend/src/components/form/formSections/FormCasePlan.vue
@@ -64,10 +64,18 @@ export default {
     async getCasePlanInterventionAPI() {
         this.loading = true;
         const [error, interventionData] = await getCasePlanIntervention(this.csNumber, this.clientFormId, true);
+        // console.log("getCasePlanIntervention: {}", interventionData);
         if (error) {
             console.error(error);
         } else {
             this.loading = false;
+            // Deal with special case where intervention is attached to a section comment, rather than a section question.
+            interventionData.forEach(dataset => {
+              if (dataset.comment == null || dataset.comment == '') {
+                dataset.comment = dataset.value;
+              }
+            });
+            
             // add Intervention data to the initData; refresh the page to show it
             this.initData.data.interventions = interventionData;
             //console.log("interventionData; ", this.initData.data.interventions);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- CBCCCM-960: Intervention Comment not pulling through to case plan

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
