### PR TITLE
Custody-CMRP Print Layout fixes

### DIFF
--- a/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientDataServiceImpl.java
+++ b/cccm-backend/cccm-api/src/main/java/ca/bc/gov/open/jag/api/service/ClientDataServiceImpl.java
@@ -258,8 +258,7 @@ public class ClientDataServiceImpl implements ClientDataService {
                 formsMerged.add(populateRatings(form, clientNum, location));
             } else if (formTypeCd.equalsIgnoreCase(CUSTODY_CMRP_FORM_TYPE) && form.getModule().equalsIgnoreCase(CUSTODY_CMRP_FORM_TYPE)) {
                 logger.info("adding form {}", form.getModule());
-                //Required when searching for only cmrp. But is not displayed...
-                form.setSupervisionRating(form.getRatings().get(0).getText());
+
                 formsMerged.add(form);
             }
         }

--- a/cccm-frontend/src/components/PrintView.vue
+++ b/cccm-frontend/src/components/PrintView.vue
@@ -49,7 +49,8 @@
                                 <v-data-table v-else-if="subSection.title == 'Responsivity Factors' || showCMRPSections(section.section, formEle.formType)"
                                     no-data-text="" 
                                     :items="subSection.answers"
-                                    :headers="formHeaders" item-key="key" 
+                                    :headers="subSection.noComments ? formNoCommentsHeaders : formHeaders"
+                                    item-key="key"
                                     no-results-text="No results found" 
                                     hide-default-footer>
                                 </v-data-table>
@@ -57,7 +58,7 @@
                                                     || subSection.title == 'Assessment Comments'
                                                     || subSection.title == 'Reassessment Comments'"
                                     
-                                >{{ subSection.answers != null && subSection.answers.length == 1 ? subSection.answers[0].value : '' }}
+                                >{{ subSection.answers?.length == 1 ? subSection.answers[0].value : '' }}
                                 </pre>
                                 
                                 <br>
@@ -99,8 +100,13 @@ export default {
         loading: false,
         theKey: 0,
         formHeaders: [
-            { text: 'Responsivity Factor', value: 'question', width: '50%', sortable: false },
-            { text: 'Comments', value: 'value', width: '50%', sortable: false, cellClass: 'readonly-field-text' }
+            { text: 'Question', value: 'question', width: '20%', sortable: false },
+            { text: 'Answer', value: 'value', width: '40%', sortable: false, cellClass: 'readonly-field-text' },
+            { text: 'Comments', value: 'comment', width: '40%', cellClass: 'readonly-field-text' }
+        ],
+        formNoCommentsHeaders: [
+          { text: 'Question', value: 'question', width: '20%', sortable: false },
+          { text: 'Answer', value: 'value', width: '80%', sortable: false, cellClass: 'readonly-field-text' }
         ],
         interventionHeaders: [
             { text: 'Criminogenic Needs', value: 'question', width: '10%', sortable: false },

--- a/cccm-frontend/src/components/RNAList.vue
+++ b/cccm-frontend/src/components/RNAList.vue
@@ -598,13 +598,13 @@ export default {
             // All other SMO form types, there should be only the rating for the specific form type
             if (el.ratings != null) {
               el.ratings.filter(rating => {
-                if (rating.formType == this.$CONST_FORMTYPE_CRNA) {
+                if (rating.formType == this.$CONST_FORMTYPE_CRNA || rating.formType == this.$CONST_FORMTYPE_CMRP) {
                   el.crnaRating = rating.desc;
                   el.crnaRatingVal = rating.text;
                 } else if (rating.formType == this.$CONST_FORMTYPE_SARA) {
                   el.saraRating = rating.desc;
                   el.saraRatingVal = rating.text;
-                } else if (rating.formType != this.$CONST_FORMTYPE_CMRP) {
+                } else {
                   el.smoRating = rating.desc;
                   el.smoRatingVal = rating.text;
                   // Don't show supervisionRating for SMO forms other than SMO_Overall


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- CBCCCM-1078: Print Layout - add sections custody transition & release plan and info for community PO
- CBCCCM-1095: Custody CMRP should display CRNA rating under "CRNA Rating" not "SMO Rating"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
