### PR TITLE
CBCCCM-1158 Updated error message wording

### DIFF
--- a/cccm-frontend/src/components/CmpForm.vue
+++ b/cccm-frontend/src/components/CmpForm.vue
@@ -128,7 +128,7 @@ export default {
       if (currentPathClientFormId != item.formId) {
         const saveSuccess = await this.autosaveStore.flushPendingChanges();
         if (!saveSuccess) {
-          window.alert('Unable to save pending changes. Please try again before switching forms.');
+          window.alert('Network error, unable to save. Please refresh browser before continuing.');
           return;
         }
 

--- a/cccm-frontend/src/components/form/FormRenderer.vue
+++ b/cccm-frontend/src/components/form/FormRenderer.vue
@@ -652,19 +652,19 @@ export default {
         }
       });
     },
-    async flushPendingAutosaveOrReport(actionName) {
+    async flushPendingAutosaveOrReport() {
       const saveSuccess = await this.autosaveStore.flushPendingChanges();
       if (!saveSuccess) {
         this.errorOccurred = true;
-        this.errorTitle = 'Unable to save pending changes';
-        this.errorText = [{ message: 'Please retry before ' + actionName + '.' }];
+        this.errorTitle = 'Network error, unable to save.';
+        this.errorText = [{ message: 'Please refresh browser before continuing.' }];
         this.errorKey++;
       }
       return saveSuccess;
     },
     async handleSaveClose() {
       //console.log("handleSaveClose");
-      const saveSuccess = await this.flushPendingAutosaveOrReport('closing the form');
+      const saveSuccess = await this.flushPendingAutosaveOrReport();
       if (!saveSuccess) {
         return;
       }
@@ -688,7 +688,7 @@ export default {
     async handleSaveContinue(continueToNextSection) {
       //console.log("handleSaveContinue, continueToNextSection: ", continueToNextSection);
       if (continueToNextSection) {
-        const saveSuccess = await this.flushPendingAutosaveOrReport('continuing to the next section');
+        const saveSuccess = await this.flushPendingAutosaveOrReport();
         if (!saveSuccess) {
           return;
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

CBCCCM-1158 Updated wording on error message if autosaving failed.

<img width="1343" height="156" alt="image" src="https://github.com/user-attachments/assets/d30772f9-302f-415c-ad4c-165282f026fc" />


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
